### PR TITLE
Respawn backpack - first implementation

### DIFF
--- a/OPCB/economy/fnc/OPCB_econ_fnc_getTierCost.sqf
+++ b/OPCB/economy/fnc/OPCB_econ_fnc_getTierCost.sqf
@@ -107,7 +107,7 @@ switch (_tierType) do {
 			case 8: {10};
 			case 7: {15};
 			case 6: {20};
-			case 5: {25};
+			case 5: {1500};
 			case 4: {35};
 			case 3: {45};
 			case 2: {65};

--- a/OPCB/economy/tierList_STATIC.sqf
+++ b/OPCB/economy/tierList_STATIC.sqf
@@ -33,7 +33,7 @@ OPCB_econ_TierList_STAT = [
 
 	//TIER 6
 	[
-
+	"B_Respawn_TentDome_F"
 	],
 
 	//TIER 7


### PR DESCRIPTION
- added backpack to static-store in Tier 6. Said backpack will act as a respawnpoint when deployed.
- set price for corresponding Tier to 1500 credits. Further balancing may be requiered.