### PR TITLE
Ambient flyby changes

### DIFF
--- a/OPCB/sideMissions/fn_ambientFlyby.sqf
+++ b/OPCB/sideMissions/fn_ambientFlyby.sqf
@@ -1,4 +1,4 @@
-private _planes = ["C_Plane_Civil_01_F","RHS_A10","RHS_C130J","rhsusf_f22","RHSGREF_A29B_HIDF"];
+private _planes = ["C_Plane_Civil_01_F","Do228","RHS_C130J","B_Plane_CAS_01_dynamicLoadout_F","RHS_AN2_B","B_Plane_Fighter_01_Stealth_F","L159ALCA","Yak130"];
 sleep 10;
 while {true} do {
 	if(count allPlayers > 0) then {


### PR DESCRIPTION
- removed RHS A-10, RHS F-22 and RHS Super Tucano due to their ejection seats cluttering the map and not properly despawning and replaced them with vanilla counterparts
- added Do 228, Yak 130 and L-39 in BadCo livery to the flyby