### PR TITLE
Whitelist:Helicopter pilots

### DIFF
--- a/OPCB/data/whitelistedUnitTypes.sqf
+++ b/OPCB/data/whitelistedUnitTypes.sqf
@@ -1,1 +1,1 @@
-_whitelistedUnitTypes = ["rhsusf_usmc_marpat_d_uav", "rhsusf_airforce_jetpilot"]; 
+_whitelistedUnitTypes = ["rhsusf_usmc_marpat_d_uav","rhsusf_airforce_jetpilot","rhsusf_army_ocp_helipilot"]; 


### PR DESCRIPTION
- forced whitelist on all pilotslots
- planned changes: two-stage whitelist, where first stage is transport only and second stage includes attack AC