### PR TITLE
Request:disabled Tier 1 vehicle

### DIFF
--- a/OPCB/economy/tierList_INF.sqf
+++ b/OPCB/economy/tierList_INF.sqf
@@ -96,11 +96,11 @@ OPCB_econ_TierList_INF = [
 
 	//TIER 10
 	[
-	"C_OFFROAD_01_F",
+	/*"C_OFFROAD_01_F",
 	"C_OFFROAD_02_UNARMED_F",
 	"RHSUSF_MRZR4_D",
 	"C_VAN_01_FUEL_F",
-	"C_VAN_02_MEDEVAC_F"
+	"C_VAN_02_MEDEVAC_F"*/
 	]
 
 ];


### PR DESCRIPTION
- disabled cheap T1 vehicles by player request to avoid cheap-spamming.

Optimal solution: disable/lock lower tiers, as players gain more access.