### PR TITLE
Update fn_ambientFlyby.sqf

### DIFF
--- a/OPCB/sideMissions/fn_ambientFlyby.sqf
+++ b/OPCB/sideMissions/fn_ambientFlyby.sqf
@@ -5,7 +5,7 @@ while {true} do {
 		[west, "HQ"] sideChat "Ambient FlyBy started!";
 		private _playerPos = getPosATL (selectRandom allPlayers);
 
-		[[0,0],_playerPos getPos [5000, ([0,0] getDir _playerPos)], 50, "NORMAL", selectRandom _planes, civ] call BIS_fnc_ambientFlyby;
+		[[0,0],_playerPos getPos [5000, ([0,0] getDir _playerPos)], 100, "NORMAL", selectRandom _planes, civ] call BIS_fnc_ambientFlyby;
 
 	};
 	sleep random [600, 1200, 1800];

--- a/OPCB/sideMissions/fn_ambientFlyby.sqf
+++ b/OPCB/sideMissions/fn_ambientFlyby.sqf
@@ -5,7 +5,7 @@ while {true} do {
 		[west, "HQ"] sideChat "Ambient FlyBy started!";
 		private _playerPos = getPosATL (selectRandom allPlayers);
 
-		[[0,0],_playerPos getPos [5000, ([0,0] getDir _playerPos)], 50, "NORMAL", selectRandom _planes, west] call BIS_fnc_ambientFlyby;
+		[[0,0],_playerPos getPos [5000, ([0,0] getDir _playerPos)], 50, "NORMAL", selectRandom _planes, civ] call BIS_fnc_ambientFlyby;
 
 	};
 	sleep random [600, 1200, 1800];

--- a/OPCB/sideMissions/fn_ambientFlyby.sqf
+++ b/OPCB/sideMissions/fn_ambientFlyby.sqf
@@ -5,7 +5,7 @@ while {true} do {
 		[west, "HQ"] sideChat "Ambient FlyBy started!";
 		private _playerPos = getPosATL (selectRandom allPlayers);
 
-		[[0,0],_playerPos getPos [5000, ([0,0] getDir _playerPos)], 100, "NORMAL", selectRandom _planes, civ] call BIS_fnc_ambientFlyby;
+		[[0,0],_playerPos getPos [5000, ([0,0] getDir _playerPos)], 100, "NORMAL", selectRandom _planes, east] call BIS_fnc_ambientFlyby;
 
 	};
 	sleep random [600, 1200, 1800];


### PR DESCRIPTION
Possible fix for players being able to take over Drongo flyby aircraft

Should make them not appear in drongo menu