### PR TITLE
Patrol fixes

### DIFF
--- a/OPCB/insurgency/common/initserver-common.sqf
+++ b/OPCB/insurgency/common/initserver-common.sqf
@@ -151,7 +151,7 @@ cleanupVics = [];
 
   waitUntil {
     sleep 10;
-    ((count playableUnits) > 1) || {!isMultiplayer}
+    ((count playableUnits) > 0) || {!isMultiplayer}
   };
 
   #ifdef ENABLE_TIERED_UNITS

--- a/OPCB/insurgency/common/server/AI/UPS.sqf
+++ b/OPCB/insurgency/common/server/AI/UPS.sqf
@@ -29,7 +29,7 @@
 #define SAFEDIST 150
 
 // how close unit has to be to target to generate a new one 
-#define CLOSEENOUGH 100
+#define CLOSEENOUGH 500
 
 // how close units have to be to each other to share information
 #define SHAREDIST (worldSize/8)
@@ -37,11 +37,10 @@
 // how long AI units should be in alert mode after initially spotting an enemy
 #define ALERTTIME 900
 
-private __CENTERPOS = getArray (configFile >> "CfgWorlds" >> worldName >> "centerPosition");
-__CENTERPOS set [2, 0];
-
-#define DEFAULT_RANGEX (worldSize/2)
-#define DEFAULT_RANGEY (worldSize/2)
+private __CENTERPOS = [10000,10000];
+__CENTERPOS set [10000,10000];
+#define DEFAULT_RANGEX (worldSize/2);
+#define DEFAULT_RANGEY (worldSize/2);
 
 nearestPlayers = {
 	private ["_result","_pos","_range","_type","_alive"];
@@ -164,6 +163,7 @@ if (_isair) then {
 _vicHasNoGun = false;
 
 if (_isLandVehicle) then {
+	_npc setSpeedMode "LIMITED";
 	_npc setUnloadInCombat [true, true];
 	if ((isNull (gunner _npc)) && {(_npc emptyPositions "Gunner") == 0}) then {
 		_vicHasNoGun = true;
@@ -694,7 +694,7 @@ while { _loop} do {
 						_posX = _targetPos select 0;
 						_posY = _targetPos select 1;
 						if (isNil "_posX" || isNil "_posY") then { _targetPos = __CENTERPOS; };
-						_roadlist = _targetPos nearRoads 200;
+						_roadlist = _targetPos nearRoads 1000;
 						if (count _roadlist>0) then { _targetPos = getPosATL (_roadlist select 0); };
 						//_road=[_targetPos,(_isair||_isboat),_road] call KRON_OnRoad; 
 						sleep .01; 			

--- a/OPCB/insurgency/defines.sqf
+++ b/OPCB/insurgency/defines.sqf
@@ -4,8 +4,9 @@
 //spawnPos must remain available in global missionNamespace, a definition does not
 // do not touch any of these except the last two
 spawnPos =					[0,0,50000];
-#define CENTERPOS			getArray (configFile >> "CfgWorlds" >> worldName >> "centerPosition")
-#define AORADIUS 			((sqrt 2 / 2 * worldSize)*1.5)
+// Set manually on Mehland
+#define CENTERPOS			[10000,10000,120]
+#define AORADIUS 			((sqrt 2 / 2 * worldSize)*0.9)
 
 // TODO Hunter: modernise house checks and get rid of these...
 #define CACHEHOUSEPOSITIONS ["Land_House_K_1_EP1",[1,2,3,4],"Land_House_L_4_EP1",[6],"Land_House_C_5_V3_EP1",[0,2,6],"Land_House_C_12_EP1",[5,6],"Land_House_K_3_EP1",[9,1,2,3,5],"Land_House_C_5_V2_EP1",[4,0,1,5],"Land_House_L_8_EP1",[7,8],"Land_House_C_4_EP1",[7,12,13,15],"Land_House_C_2_EP1",[1,2,5,6,7,8,9],"Land_House_L_7_EP1",[0,1,2,3,4,5],"Land_House_C_10_EP1",[7,8,9,10,11,12,13,14],"Land_House_K_6_EP1",[6,7,8,9,10],"Land_House_C_11_EP1",[7,8,9,10],"Land_House_C_9_EP1",[2,3,4,5],"Land_House_C_3_EP1",[7,8,9,10,11,12,13,28,29,30,31,32],"Land_A_Office01_EP1",[5,6],"Land_A_Mosque_small_1_EP1",[3,4,5],"Land_A_Stationhouse_ep1",[6,9,13],"Land_House_C_5_EP1",[3,4,5],"Land_House_K_7_EP1",[4,5,6,11],"Land_Mil_ControlTower_EP1",[2,3,4,6],"Land_House_C_5_V1_EP1",[6,7],"Land_House_K_8_EP1",[4,0,1,2,3],"Land_A_BuildingWIP_EP1",[18,20,24,25,26,27,28,29,30,31],"Land_A_Villa_EP1",[4,6,7,8,9],"Land_House_C_1_EP1",[3],"Land_House_L_6_EP1",[4,0,3],"Land_House_L_3_EP1",[0,1,2],"Land_House_K_5_EP1",[1,2],"Land_House_C_1_v2_EP1",[0,1,2,3]]
@@ -15,6 +16,6 @@ spawnPos =					[0,0,50000];
 //#define EP1HOUSES			(configName(inheritsFrom (configFile >> "CfgVehicles" >> typeOf _x)) == "HOUSE_EP1")
 #define EP1HOUSES			true
 
-#define randPos				[(CENTERPOS select 0)+random 6000-random 6000,(CENTERPOS select 1)+random 6000-random 6000, 0]
+#define randPos				[(CENTERPOS select 0)+random 10000-random 20000,(CENTERPOS select 1)+random 10000-random 20000, 0]
 #define cacheRadius		 	1000 // min distance at which players and other caches need to be to spawn a new cache
 #define intelRadius			4000 // starting intel distance to cache

--- a/OPCB/insurgency/params.sqf
+++ b/OPCB/insurgency/params.sqf
@@ -7,9 +7,9 @@ maxAIPerPlayer = 2.8;
 playersNeeded = 2;
 
 // max number of map patrol vehicles allowed to be active at the same time
-eastVehicleNum = 6;
+eastVehicleNum = 12;
 
-patrolSpawnDelay = 1200;
+patrolSpawnDelay = 120;
 
 ins_AIspawnMaxRange = switch (toLower worldName) do {
 	case "zargabad" : {700};

--- a/mission-files/Mehland/mission.sqm
+++ b/mission-files/Mehland/mission.sqm
@@ -22878,7 +22878,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=1174;
+		items=1175;
 		class Item0
 		{
 			dataType="Logic";
@@ -26693,39 +26693,37 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={38.251617,14.966257,1967.1611};
-				angles[]={6.2438059,1.2323351,0.035384554};
+				position[]={5748.4517,17.334871,10645.668};
+				angles[]={6.277586,1.2323351,6.2392149};
 			};
 			name="vclSpawn1";
 			id=466;
 			type="Logic";
-			atlOffset=1.9073486e-06;
 		};
 		class Item89
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={20444.566,24.012987,7583.5439};
-				angles[]={0.035784964,2.6010439,0.013398951};
+				position[]={51.587132,79.806137,8142.8936};
+				angles[]={0,2.6010439,0};
 			};
 			name="vclSpawn2";
 			id=467;
 			type="Logic";
-			atlOffset=0.15267944;
+			atlOffset=1.9749985;
 		};
 		class Item90
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={13458.523,27.654581,20441.389};
-				angles[]={6.2346244,3.055604,6.2818046};
+				position[]={20474.34,23.807173,7588.5713};
+				angles[]={0.041375965,3.055604,0.002990101};
 			};
 			name="vclSpawn3";
 			id=468;
 			type="Logic";
-			atlOffset=3.8146973e-06;
 		};
 		class Item91
 		{
@@ -28021,7 +28019,7 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={647.84021,65.173149,17441.063};
+				position[]={647.84021,65.173149,17441.062};
 				angles[]={0,3.3113534,0};
 			};
 			side="Empty";
@@ -30230,7 +30228,7 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={817.92474,63.943127,17725.313};
+				position[]={817.92474,63.943127,17725.312};
 				angles[]={0,5.8236146,0};
 			};
 			side="Empty";
@@ -32139,7 +32137,7 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={689.66406,64.892548,17411.563};
+				position[]={689.66406,64.892548,17411.562};
 				angles[]={0,2.9008005,0};
 			};
 			side="Empty";
@@ -32338,7 +32336,7 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={688.51263,64.320572,17421.063};
+				position[]={688.51263,64.320572,17421.062};
 				angles[]={0,5.2557716,0};
 			};
 			side="Empty";
@@ -40323,7 +40321,7 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={771.73718,68.244049,17491.813};
+				position[]={771.73718,68.244049,17491.812};
 				angles[]={0,0.79389489,0};
 			};
 			side="Empty";
@@ -40889,14 +40887,14 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={20444.883,23.845903,7584.0654};
-				angles[]={0.035784964,4.4693346,0.013398951};
+				position[]={51.903538,79.644623,8143.415};
+				angles[]={0,4.4693346,0};
 			};
 			areaSize[]={60,0,60};
 			flags=1;
 			id=4355;
 			type="ModuleHideTerrainObjects_F";
-			atlOffset=2.0980835e-05;
+			atlOffset=1.8223724;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -40933,14 +40931,14 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={41.018154,15.099047,1967.5496};
-				angles[]={6.2438059,1.4234905,0.054545831};
+				position[]={5746.9487,17.411898,10643.297};
+				angles[]={0.0086040357,1.4234905,6.2392135};
 			};
 			areaSize[]={50,0,50};
 			flags=1;
 			id=4356;
 			type="ModuleHideTerrainObjects_F";
-			atlOffset=9.5367432e-07;
+			atlOffset=1.9073486e-06;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -40977,14 +40975,13 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={13458.679,27.68759,20442.066};
-				angles[]={6.2342243,4.5684514,6.2822089};
+				position[]={20474.324,23.780117,7589.2236};
+				angles[]={0.041375965,4.5684514,0.002990101};
 			};
-			areaSize[]={60,0,60};
+			areaSize[]={60,0,60.171677};
 			flags=1;
 			id=4357;
 			type="ModuleHideTerrainObjects_F";
-			atlOffset=3.8146973e-06;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -53554,7 +53551,7 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={999.82745,63.700001,17632.063};
+				position[]={999.82745,63.700001,17632.062};
 			};
 			id=7485;
 			type="DAO_PreferredAirfield";
@@ -58279,7 +58276,7 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={659.61066,64.769081,17357.063};
+				position[]={659.61066,64.769081,17357.062};
 				angles[]={0,4.4958777,0};
 			};
 			side="Empty";
@@ -60547,7 +60544,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={819.09534,69.140083,18035.063};
+						position[]={819.09534,69.140083,18035.062};
 						angles[]={0,1.134464,0};
 					};
 					side="West";
@@ -66077,7 +66074,7 @@ class Mission
 		{
 			dataType="Trigger";
 			position[]={692.43372,63.700001,17462.053};
-			angle=2.9035814;
+			angle=2.9035807;
 			class Attributes
 			{
 				name="ShopRS";

--- a/mission-files/Mehland/mission.sqm
+++ b/mission-files/Mehland/mission.sqm
@@ -22878,7 +22878,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=1175;
+		items=1174;
 		class Item0
 		{
 			dataType="Logic";
@@ -26693,37 +26693,39 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={5748.4517,17.334871,10645.668};
-				angles[]={6.277586,1.2323351,6.2392149};
+				position[]={38.251617,14.966257,1967.1611};
+				angles[]={6.2438059,1.2323351,0.035384554};
 			};
 			name="vclSpawn1";
 			id=466;
 			type="Logic";
+			atlOffset=1.9073486e-06;
 		};
 		class Item89
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={51.587132,79.806137,8142.8936};
-				angles[]={0,2.6010439,0};
+				position[]={20444.566,24.012987,7583.5439};
+				angles[]={0.035784964,2.6010439,0.013398951};
 			};
 			name="vclSpawn2";
 			id=467;
 			type="Logic";
-			atlOffset=1.9749985;
+			atlOffset=0.15267944;
 		};
 		class Item90
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={20474.34,23.807173,7588.5713};
-				angles[]={0.041375965,3.055604,0.002990101};
+				position[]={13458.523,27.654581,20441.389};
+				angles[]={6.2346244,3.055604,6.2818046};
 			};
 			name="vclSpawn3";
 			id=468;
 			type="Logic";
+			atlOffset=3.8146973e-06;
 		};
 		class Item91
 		{
@@ -28019,7 +28021,7 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={647.84021,65.173149,17441.062};
+				position[]={647.84021,65.173149,17441.063};
 				angles[]={0,3.3113534,0};
 			};
 			side="Empty";
@@ -30228,7 +30230,7 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={817.92474,63.943127,17725.312};
+				position[]={817.92474,63.943127,17725.313};
 				angles[]={0,5.8236146,0};
 			};
 			side="Empty";
@@ -32137,7 +32139,7 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={689.66406,64.892548,17411.562};
+				position[]={689.66406,64.892548,17411.563};
 				angles[]={0,2.9008005,0};
 			};
 			side="Empty";
@@ -32336,7 +32338,7 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={688.51263,64.320572,17421.062};
+				position[]={688.51263,64.320572,17421.063};
 				angles[]={0,5.2557716,0};
 			};
 			side="Empty";
@@ -40321,7 +40323,7 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={771.73718,68.244049,17491.812};
+				position[]={771.73718,68.244049,17491.813};
 				angles[]={0,0.79389489,0};
 			};
 			side="Empty";
@@ -40887,14 +40889,14 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={51.903538,79.644623,8143.415};
-				angles[]={0,4.4693346,0};
+				position[]={20444.883,23.845903,7584.0654};
+				angles[]={0.035784964,4.4693346,0.013398951};
 			};
 			areaSize[]={60,0,60};
 			flags=1;
 			id=4355;
 			type="ModuleHideTerrainObjects_F";
-			atlOffset=1.8223724;
+			atlOffset=2.0980835e-05;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -40931,14 +40933,14 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={5746.9487,17.411898,10643.297};
-				angles[]={0.0086040357,1.4234905,6.2392135};
+				position[]={41.018154,15.099047,1967.5496};
+				angles[]={6.2438059,1.4234905,0.054545831};
 			};
 			areaSize[]={50,0,50};
 			flags=1;
 			id=4356;
 			type="ModuleHideTerrainObjects_F";
-			atlOffset=1.9073486e-06;
+			atlOffset=9.5367432e-07;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -40975,13 +40977,14 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={20474.324,23.780117,7589.2236};
-				angles[]={0.041375965,4.5684514,0.002990101};
+				position[]={13458.679,27.68759,20442.066};
+				angles[]={6.2342243,4.5684514,6.2822089};
 			};
-			areaSize[]={60,0,60.171677};
+			areaSize[]={60,0,60};
 			flags=1;
 			id=4357;
 			type="ModuleHideTerrainObjects_F";
+			atlOffset=3.8146973e-06;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -53551,7 +53554,7 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={999.82745,63.700001,17632.062};
+				position[]={999.82745,63.700001,17632.063};
 			};
 			id=7485;
 			type="DAO_PreferredAirfield";
@@ -58276,7 +58279,7 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={659.61066,64.769081,17357.062};
+				position[]={659.61066,64.769081,17357.063};
 				angles[]={0,4.4958777,0};
 			};
 			side="Empty";
@@ -60544,7 +60547,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={819.09534,69.140083,18035.062};
+						position[]={819.09534,69.140083,18035.063};
 						angles[]={0,1.134464,0};
 					};
 					side="West";
@@ -66074,7 +66077,7 @@ class Mission
 		{
 			dataType="Trigger";
 			position[]={692.43372,63.700001,17462.053};
-			angle=2.9035807;
+			angle=2.9035814;
 			class Attributes
 			{
 				name="ShopRS";


### PR DESCRIPTION
-Fixed patrols geting waypoints out of bounds of map
- Allowed patrol spawns with just 1 player on the server
- Fixed center of the map not being centered
- Adjusted AOsize to be just about the size of the map
- Adjusted AI driving mode, they should drive a bit slower preventing some of the crashes
- Changed randomization script to allow waypoints on whole map
- Adjusted spawning of waypoints too far away from any roads


Should work without mission.sqm update below but provided changes should bring less geting stuck short after respawn